### PR TITLE
Done: Task IR 11 System configuration

### DIFF
--- a/src/main/java/acme/components/SystemConfiguration.java
+++ b/src/main/java/acme/components/SystemConfiguration.java
@@ -1,0 +1,6 @@
+package acme.components;
+
+
+public class SystemConfiguration {
+
+}

--- a/src/main/java/acme/components/SystemConfiguration.java
+++ b/src/main/java/acme/components/SystemConfiguration.java
@@ -1,6 +1,31 @@
 package acme.components;
 
+import javax.persistence.Entity;
+import javax.validation.constraints.NotBlank;
 
-public class SystemConfiguration {
+import acme.framework.entities.AbstractEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class SystemConfiguration extends AbstractEntity {
+	
+//	Serialization identifier
+	
+	protected static final long serialVersionUID = 1l;
+	
+//	Atributes
+	
+//	 A system currency, which must be “EUR” by default.
+//	 A list of accepted currencies, which must be initialised to “EUR”, “USD”, and “GBP”.
+//	 A list of strong spam terms, which must include “sex”, “hard core”, “viagra”, “cialis”, and their Spanish translations by default.
+//	 A strong spam threshold, which must be 10% by default.
+//	 A list of weak spam terms, which must include “sexy”, “nigeria", “you’ve won”, “one mil-lion”, and their corresponding Spanish translations by default.
+//	 A weak spam threshold, which must be 25% by default.
+	
+	@NotBlank
+	protected final SystemCurrency defaultCurrency = SystemCurrency.EUR;
 
 }

--- a/src/main/java/acme/components/SystemConfiguration.java
+++ b/src/main/java/acme/components/SystemConfiguration.java
@@ -26,6 +26,22 @@ public class SystemConfiguration extends AbstractEntity {
 //	 A weak spam threshold, which must be 25% by default.
 	
 	@NotBlank
-	protected final SystemCurrency defaultCurrency = SystemCurrency.EUR;
+	protected static final SystemCurrency defaultCurrency = SystemCurrency.EUR;
+	
+	@NotBlank
+	protected static final String acceptedCurrencies = SystemCurrency.EUR.toString() + SystemCurrency.GBP.toString() + SystemCurrency.USD.toString();
+		
+	@NotBlank
+	protected static final String strongSpamTerms = "sex, hard core, viagra, cialis";
+	
+	@NotBlank
+	protected static final Double strongThreshold = .1;
+	
+	@NotBlank
+	protected static final String weakSpamTerms = "sexy, nigeria, you’ve won, one mil-lion";
+	
+	@NotBlank
+	protected static final Double weakThreshold = .25;
+	
 
 }

--- a/src/main/java/acme/components/SystemCurrency.java
+++ b/src/main/java/acme/components/SystemCurrency.java
@@ -1,0 +1,8 @@
+package acme.components;
+
+
+public enum SystemCurrency {
+	
+	EUR, USD, GBP
+
+}

--- a/src/main/java/acme/entities/Announcement.java
+++ b/src/main/java/acme/entities/Announcement.java
@@ -26,10 +26,6 @@ public class Announcement extends AbstractEntity{
 	
 //	Atributes
 	
-//	An announcement is a formal piece of news. The system must store the following data about them: a creation moment (in the past), a title (not blank, shorter 
-//	than 101 characters), a body (not blank, shorter than 256 characters), a flag to indicate whether they are critical or not, and an optional link with 
-//	further information.
-	
 	@NotBlank
 	@Temporal(TemporalType.DATE)
 	@Past


### PR DESCRIPTION
The system configuration must include the following initial data:
 A system currency, which must be “EUR” by default.
 A list of accepted currencies, which must be initialised to “EUR”, “USD”, and “GBP”.
 A list of strong spam terms, which must include “sex”, “hard core”, “viagra”, “cialis”, and their Spanish translations by default.
 A strong spam threshold, which must be 10% by default.
 A list of weak spam terms, which must include “sexy”, “nigeria", “you’ve won”, “one mil-lion”, and their corresponding Spanish translations by default.
 A weak spam threshold, which must be 25% by default.